### PR TITLE
Journalist can create more than one article in one run

### DIFF
--- a/cypress/integration/journalistCanCreateArticle.feature.js
+++ b/cypress/integration/journalistCanCreateArticle.feature.js
@@ -31,7 +31,6 @@ describe("Journalist can create an article", () => {
       cy.get("textarea#body").type(
         "This is the body"
       );
-
       cy.get("#category").click();
       cy.get("#category > .visible > :nth-child(2)").click();
       cy.file_upload("img.jpeg", "#image-upload", "image/jpeg");
@@ -40,8 +39,8 @@ describe("Journalist can create an article", () => {
       cy.get("#message").should("contain", "Article successfully created!");
       cy.get("input#title").should("not.have.value", "This is the title");
       cy.get("textarea#body").should("not.have.value", "This is the body");
-      cy.wait(2000);
-      cy.get("#message").should("not.exist");
+      cy.wait(3000);
+      cy.get("#message").should("not.be.visible");
     });
   });
 

--- a/cypress/integration/journalistCanCreateArticle.feature.js
+++ b/cypress/integration/journalistCanCreateArticle.feature.js
@@ -39,6 +39,7 @@ describe("Journalist can create an article", () => {
       cy.get("#message").should("contain", "Article successfully created!");
       cy.get("input#title").should("not.have.value", "This is the title");
       cy.get("textarea#body").should("not.have.value", "This is the body");
+      cy.get("#preview-image").should("not.be.visible");
       cy.wait(3000);
       cy.get("#message").should("not.be.visible");
     });

--- a/cypress/integration/journalistCanCreateArticle.feature.js
+++ b/cypress/integration/journalistCanCreateArticle.feature.js
@@ -29,7 +29,7 @@ describe("Journalist can create an article", () => {
     it("the input fields are cleared on submission", () => {
       cy.get("input#title").type("This is the title");
       cy.get("textarea#body").type(
-        "This is the body this is the body this is the body this is the body this is the body."
+        "This is the body"
       );
 
       cy.get("#category").click();
@@ -38,8 +38,8 @@ describe("Journalist can create an article", () => {
       cy.get("#preview-image").should("be.visible");
       cy.get("#post").click();
       cy.get("#message").should("contain", "Article successfully created!");
-      cy.get("input#title").should("be.empty");
-      cy.get("input#body").should("be.empty");
+      cy.get("input#title").should("not.have.value", "This is the title");
+      cy.get("textarea#body").should("not.have.value", "This is the body");
       cy.wait(2000);
       cy.get("#message").should("not.exist");
     });

--- a/cypress/integration/journalistCanCreateArticle.feature.js
+++ b/cypress/integration/journalistCanCreateArticle.feature.js
@@ -1,65 +1,90 @@
 describe("Journalist can create an article", () => {
   beforeEach(() => {
-    cy.login('journalist');
+    cy.login("journalist");
   });
 
-  it("successfully with title, body, image and category", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles*",
-      response: "fixture:success_message.json",
+  describe("successfully", () => {
+    beforeEach(() => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/articles*",
+        response: "fixture:success_message.json",
+      });
     });
-    cy.get("input#title").type("This is the title");
-    cy.get("textarea#body").type(
-      "This is the body this is the body this is the body this is the body this is the body."
-    );
 
-    cy.get('#category').click()
-    cy.get('#category > .visible > :nth-child(2)').click()
-    cy.file_upload("img.jpeg", "#image-upload", "image/jpeg");
-    cy.get("#preview-image").should("be.visible");
-    cy.get("#post").click();
-    cy.get("#message").should("contain", "Article successfully created!");
+    it("with title, body, image and category", () => {
+      cy.get("input#title").type("This is the title");
+      cy.get("textarea#body").type(
+        "This is the body this is the body this is the body this is the body this is the body."
+      );
+
+      cy.get("#category").click();
+      cy.get("#category > .visible > :nth-child(2)").click();
+      cy.file_upload("img.jpeg", "#image-upload", "image/jpeg");
+      cy.get("#preview-image").should("be.visible");
+      cy.get("#post").click();
+      cy.get("#message").should("contain", "Article successfully created!");
+    });
+
+    it("the input fields are cleared on submission", () => {
+      cy.get("input#title").type("This is the title");
+      cy.get("textarea#body").type(
+        "This is the body this is the body this is the body this is the body this is the body."
+      );
+
+      cy.get("#category").click();
+      cy.get("#category > .visible > :nth-child(2)").click();
+      cy.file_upload("img.jpeg", "#image-upload", "image/jpeg");
+      cy.get("#preview-image").should("be.visible");
+      cy.get("#post").click();
+      cy.get("#message").should("contain", "Article successfully created!");
+      cy.get("input#title").should("be.empty");
+      cy.get("input#body").should("be.empty");
+      cy.wait(2000);
+      cy.get("#message").should("not.exist");
+    });
   });
 
-  it("unsuccessfully without entering any title", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles*",
-      response: "fixture:title_blank_message.json",
-      status: 400,
+  describe("unsuccessfully", () => {
+    it("without entering any title", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/articles*",
+        response: "fixture:title_blank_message.json",
+        status: 400,
+      });
+      cy.get("textarea#body").type(
+        "This is the body this is the body this is the body this is the body this is the body."
+      );
+      cy.get("#post").click();
+      cy.get("#message").should("contain", "Title can't be blank");
     });
-    cy.get("textarea#body").type(
-      "This is the body this is the body this is the body this is the body this is the body."
-    );
-    cy.get("#post").click();
-    cy.get("#message").should("contain", "Title can't be blank");
-  });
 
-  it("unsuccessfully without entering any body text", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles*",
-      response: "fixture:body_blank_message.json",
-      status: 400,
+    it("without entering any body text", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/articles*",
+        response: "fixture:body_blank_message.json",
+        status: 400,
+      });
+      cy.get("input#title").type("This is the title");
+      cy.get("#post").click();
+      cy.get("#message").should("contain", "Body can't be blank");
     });
-    cy.get("input#title").type("This is the title");
-    cy.get("#post").click();
-    cy.get("#message").should("contain", "Body can't be blank");
-  });
 
-  it("unsuccessfully without uploading image", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles*",
-      response: "fixture:image_blank_message.json",
-      status: 400,
+    it("without uploading image", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/articles*",
+        response: "fixture:image_blank_message.json",
+        status: 400,
+      });
+      cy.get("input#title").type("This is the title");
+      cy.get("textarea#body").type(
+        "This is the body this is the body this is the body this is the body this is the body."
+      );
+      cy.get("#post").click();
+      cy.get("#message").should("contain", "Image can't be blank");
     });
-    cy.get("input#title").type("This is the title");
-    cy.get("textarea#body").type(
-      "This is the body this is the body this is the body this is the body this is the body."
-    );
-    cy.get("#post").click();
-    cy.get("#message").should("contain", "Image can't be blank");
   });
 });

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -38,7 +38,9 @@ const CreateArticle = () => {
         },
         { headers: headers }
       );
+      e.target.reset()
       setMessage(response.data.message);
+      setTimeout(() => {setMessage("")}, 3000)
     } catch (error) {
       setMessage(error.response.data.message);
     }

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -39,6 +39,7 @@ const CreateArticle = () => {
         { headers: headers }
       );
       e.target.reset()
+      setImagePreview("")
       setMessage(response.data.message);
       setTimeout(() => {setMessage("")}, 3000)
     } catch (error) {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -46,7 +46,7 @@ p {
   padding: 20px;
   background-color: #409d9b;
   min-height: 35vh;
-  width: 15vw;
+  width: 270px;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
# User story
[PT LINK](https://www.pivotaltracker.com/story/show/173102286)
```
As a journalist
In order to write more than one article in a row
I would like the Write page fields to be cleared when an article is submitted and ready for writing another
```

# Feature
* Input fields are cleared when an article is submitted, so that the journalist can submit another one

## This PR contains:
* Functions to clear the form, the image preview and sets a timeout on the success message, so that it disappears after 3s.
* Test included in journalistCanCreateArticle
* Correcting login-form width, for the sake of today's client meeting.
 