### PR TITLE
Editor can select location

### DIFF
--- a/cypress/integration/editorCanPreviewUnpublishedArticle.feature.js
+++ b/cypress/integration/editorCanPreviewUnpublishedArticle.feature.js
@@ -30,7 +30,7 @@ describe("Editor can see unpublished articles", () => {
       cy.get("#preview").within(() => {
         cy.get("#preview-title").should("contain", "title 1");
         cy.get("#body").should("contain", "Lorem ipsum");
-        cy.get("#image").should("be.visible");
+        cy.get(".image").should("be.visible");
       });
     });
   });

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -20,6 +20,7 @@ describe("editor can publish articles", () => {
       cy.get("#body").should("contain", "Lorem ipsum dolor");
       cy.get("#category").should("contain", "Sport");
       cy.get("#radio-free").should("be.checked");
+      cy.get("#checkbox-sweden").should("be.checked")
     });
   });
 

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -1,4 +1,9 @@
 describe("editor", () => {
+  const free = ":nth-child(2) > :nth-child(1) > label"
+  const premium = ":nth-child(2) > :nth-child(2) > label"
+  const locationSweden = ":nth-child(3) > :nth-child(1) > label" 
+  const international = ":nth-child(3) > :nth-child(2) > label" 
+  
   beforeEach(() => {
     cy.login("editor");
     cy.route({
@@ -43,9 +48,9 @@ describe("editor", () => {
     it("change category and add location and publish", () => {
       cy.get("#category").click();
       cy.get("#category > .visible > :nth-child(4)").click();
-      cy.get("#checkbox-sweden").click();
+      cy.get(locationSweden).click();
       cy.get("#checkbox-sweden").should("be.checked");
-      cy.get("#checkbox-International").click();
+      cy.get(international).click();
       cy.get("#checkbox-International").should("be.checked");
       cy.get("#publish-btn").click();
       cy.get("#success-message").should(
@@ -55,8 +60,8 @@ describe("editor", () => {
     });
 
     it("change article class and publish", () => {
-      cy.get("#checkbox-sweden").click();
-      cy.get("#radio-premium").check();
+      cy.get(locationSweden).click();
+      cy.get(premium).click();
       cy.get("#publish-btn").click();
       cy.get("#success-message").should(
         "contain",
@@ -74,8 +79,8 @@ describe("editor", () => {
       });
       cy.get("#article-1").click();
       cy.get("#checkout-article-1").click();
-      cy.get("#checkbox-sweden").click();
-      cy.get("#radio-premium").check();
+      cy.get(locationSweden).click();
+      cy.get(premium).click();
       cy.get("#publish-btn").click();
     });
 

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -1,5 +1,3 @@
-import { Button } from "semantic-ui-react";
-
 describe("editor", () => {
   beforeEach(() => {
     cy.login("editor");

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -20,8 +20,13 @@ describe("editor can publish articles", () => {
       cy.get("#body").should("contain", "Lorem ipsum dolor");
       cy.get("#category").should("contain", "Sport");
       cy.get("#radio-free").should("be.checked");
-      cy.get("#checkbox-sweden").should("be.checked")
-      cy.get("#checkbox-International").should("be.checked")
+
+      it("and adding location", () => {
+        cy.get("#checkbox-sweden").click();
+        cy.get("#checkbox-sweden").should("be.checked");
+        cy.get("#checkbox-International").click();
+        cy.get("#checkbox-International").should("be.checked");
+      });
     });
   });
 

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -21,12 +21,11 @@ describe("editor can publish articles", () => {
       cy.get("#category").should("contain", "Sport");
       cy.get("#radio-free").should("be.checked");
 
-      it("and adding location", () => {
-        cy.get("#checkbox-sweden").click();
-        cy.get("#checkbox-sweden").should("be.checked");
-        cy.get("#checkbox-International").click();
-        cy.get("#checkbox-International").should("be.checked");
-      });
+      it("check checkbox location", () => {
+        cy.get("#checkbox-sweden").should("not.be.checked")
+        cy.get("#checkbox-International").should("not.be.checked")
+    })
+      
     });
   });
 
@@ -40,9 +39,14 @@ describe("editor can publish articles", () => {
       });
     });
 
-    it("change category and publish", () => {
+    it("change category and add location and publish", () => {
       cy.get("#category").click();
       cy.get("#category > .visible > :nth-child(4)").click();
+        cy.get("#checkbox-sweden").click();
+        cy.get("#checkbox-sweden").should("be.checked")
+        cy.get("#checkbox-International").click();
+        cy.get("#checkbox-International").should("be.checked")
+  
       cy.get("#publish-btn").click();
       cy.get("#message").should("contain", "Article successfully published!");
     });

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -1,3 +1,5 @@
+import { Button } from "semantic-ui-react";
+
 describe("editor", () => {
   beforeEach(() => {
     cy.login("editor");
@@ -25,9 +27,9 @@ describe("editor", () => {
 
     it("and navigate back to list of articles", () => {
       cy.get("#checkout-article-1").click();
-      cy.get("button").contains("Back to list").click()
-      cy.get("#article-list").should('be.visible')
-    })
+      cy.get("button").contains("Back to list").click();
+      cy.get("#article-list").should("be.visible");
+    });
   });
 
   describe("can change properties and successfully publish", () => {
@@ -48,29 +50,58 @@ describe("editor", () => {
       cy.get("#checkbox-International").click();
       cy.get("#checkbox-International").should("be.checked");
       cy.get("#publish-btn").click();
-      cy.get("#success-message").should("contain", "Article successfully published!");
+      cy.get("#success-message").should(
+        "contain",
+        "Article successfully published!"
+      );
     });
 
     it("change article class and publish", () => {
       cy.get("#checkbox-sweden").click();
-      cy.get('#radio-premium').check();
+      cy.get("#radio-premium").check();
       cy.get("#publish-btn").click();
-      cy.get("#success-message").should("contain", "Article successfully published!");
+      cy.get("#success-message").should(
+        "contain",
+        "Article successfully published!"
+      );
+    });
+  });
+
+  describe("When an article is published", () => {
+    beforeEach(() => {
+      cy.route({
+        method: "PUT",
+        url: "http://localhost:3000/api/admin/articles/1",
+        response: "fixture:successful_publish.json",
+      });
+      cy.get("#article-1").click();
+      cy.get("#checkout-article-1").click();
+      cy.get("#checkbox-sweden").click();
+      cy.get("#radio-premium").check();
+      cy.get("#publish-btn").click();
     });
 
-    it('"Publish" button disappears after publishing', () => {
-      cy.get("#checkbox-sweden").click();
-      cy.get('#radio-premium').check();
-      cy.get("#publish-btn").click();
-      cy.get("#publish-btn").should('not.exist')
-    })
+    it('"Publish" button disappears', () => {
+      cy.get("#publish-btn").should("not.exist");
+    });
+
+    it("it is not shown in article preview when going back to previous page", () => {
+      cy.get("button").contains("Back to list").click();
+      cy.get("#preview-message").should(
+        "contain",
+        "Select an article in the list to preview"
+      );
+    });
   });
 
   describe("cannot publish", () => {
     it("without choosing either 'local' or 'international'", () => {
       cy.get("#checkout-article-1").click();
       cy.get("#publish-btn").click();
-      cy.get("#error-message").should("contain", "Please select either local or international");
-    })
-  })
+      cy.get("#error-message").should(
+        "contain",
+        "Please select either local or international"
+      );
+    });
+  });
 });

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -21,6 +21,7 @@ describe("editor can publish articles", () => {
       cy.get("#category").should("contain", "Sport");
       cy.get("#radio-free").should("be.checked");
       cy.get("#checkbox-sweden").should("be.checked")
+      cy.get("#checkbox-International").should("be.checked")
     });
   });
 

--- a/cypress/integration/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editorCanPublishArticles.feature.js
@@ -1,4 +1,4 @@
-describe("editor can publish articles", () => {
+describe("editor", () => {
   beforeEach(() => {
     cy.login("editor");
     cy.route({
@@ -13,23 +13,24 @@ describe("editor can publish articles", () => {
     });
     cy.get("#review-nav").click();
   });
-  describe("editor can checkout article", () => {
-    it("can view checkout article", () => {
+
+  describe("can checkout article", () => {
+    it("can view checked-out article", () => {
       cy.get("#checkout-article-1").click();
       cy.get("#preview-title").should("contain", "title 1");
       cy.get("#body").should("contain", "Lorem ipsum dolor");
       cy.get("#category").should("contain", "Sport");
       cy.get("#radio-free").should("be.checked");
-
-      it("check checkbox location", () => {
-        cy.get("#checkbox-sweden").should("not.be.checked")
-        cy.get("#checkbox-International").should("not.be.checked")
-    })
-      
     });
+
+    it("and navigate back to list of articles", () => {
+      cy.get("#checkout-article-1").click();
+      cy.get("button").contains("Back to list").click()
+      cy.get("#article-list").should('be.visible')
+    })
   });
 
-  describe("editor can change properties and publish", () => {
+  describe("can change properties and successfully publish", () => {
     beforeEach(() => {
       cy.get("#checkout-article-1").click();
       cy.route({
@@ -42,19 +43,34 @@ describe("editor can publish articles", () => {
     it("change category and add location and publish", () => {
       cy.get("#category").click();
       cy.get("#category > .visible > :nth-child(4)").click();
-        cy.get("#checkbox-sweden").click();
-        cy.get("#checkbox-sweden").should("be.checked")
-        cy.get("#checkbox-International").click();
-        cy.get("#checkbox-International").should("be.checked")
-  
+      cy.get("#checkbox-sweden").click();
+      cy.get("#checkbox-sweden").should("be.checked");
+      cy.get("#checkbox-International").click();
+      cy.get("#checkbox-International").should("be.checked");
       cy.get("#publish-btn").click();
-      cy.get("#message").should("contain", "Article successfully published!");
+      cy.get("#success-message").should("contain", "Article successfully published!");
     });
 
     it("change article class and publish", () => {
-      cy.get('[type="radio"]').last().check();
+      cy.get("#checkbox-sweden").click();
+      cy.get('#radio-premium').check();
       cy.get("#publish-btn").click();
-      cy.get("#message").should("contain", "Article successfully published!");
+      cy.get("#success-message").should("contain", "Article successfully published!");
     });
+
+    it('"Publish" button disappears after publishing', () => {
+      cy.get("#checkbox-sweden").click();
+      cy.get('#radio-premium').check();
+      cy.get("#publish-btn").click();
+      cy.get("#publish-btn").should('not.exist')
+    })
   });
+
+  describe("cannot publish", () => {
+    it("without choosing either 'local' or 'international'", () => {
+      cy.get("#checkout-article-1").click();
+      cy.get("#publish-btn").click();
+      cy.get("#error-message").should("contain", "Please select either local or international");
+    })
+  })
 });

--- a/src/components/CreateArticle.jsx
+++ b/src/components/CreateArticle.jsx
@@ -7,6 +7,7 @@ import createHeaders from "../modules/headers";
 const CreateArticle = () => {
   const [message, setMessage] = useState("");
   const [imagePreview, setImagePreview] = useState("");
+  const [loading, setLoading] = useState(false)
 
   const toBase64 = (file) =>
     new Promise((resolve, reject) => {
@@ -23,6 +24,7 @@ const CreateArticle = () => {
   const onSubmitHandler = async (e) => {
     try {
       e.persist();
+      setLoading(true)
       const category = document
         .getElementById("category")
         .firstElementChild.innerText.toLowerCase();
@@ -41,10 +43,12 @@ const CreateArticle = () => {
         { headers: createHeaders() }
       );
       e.target.reset()
-      setImagePreview("")
+      setLoading(false)
       setMessage(response.data.message);
+      setImagePreview("")
       setTimeout(() => {setMessage("")}, 3000)
     } catch (error) {
+      setLoading(false)
       setMessage(error.response.data.message);
     }
   };
@@ -56,6 +60,7 @@ const CreateArticle = () => {
           onSubmitHandler={onSubmitHandler}
           handleUploadChange={handleUploadChange}
           message={message}
+          loading={loading}
         />
       </Container>
       <Container className="writing-container">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -20,7 +20,7 @@ const Header = (props) => {
   const redirect = !authenticatedAs && <Redirect to={{ pathname: "/" }} />;
 
   return (
-    <Container className="header">
+    <Container className="header-container">
       {redirect}
       <Menu className="header" stackable>
         <Menu.Item>

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -7,24 +7,27 @@ const Preview = () => {
   const singleArticle = useSelector((state) => state.article);
 
   return (
-    <Container id="preview" align="center">
-      <Grid>
-        <Grid.Row centered>
-          <Container id="image">
-            <Image src={singleArticle.image} />
+    <>
+      <Grid.Row centered >
+        <Container align="left" id="image-container">
+          <div className="image">
+            <Image
+              src={singleArticle.image}
+              style={{ height: "400px", width: "800px" }}
+            />
             <h2 id="preview-title">{singleArticle.title}</h2>
-          </Container>
-        </Grid.Row>
-        <Grid.Row centered id="created-text">
-          Created at: {singleArticle.created_at}
-        </Grid.Row>
-        <Grid.Row centered id="preview-body">
-          <p id="body" className="article-body">
-            {singleArticle.body}
-          </p>
-        </Grid.Row>
-      </Grid>
-    </Container>
+          </div>
+        </Container>
+      </Grid.Row>
+      <Grid.Row centered id="created-text">
+        <p>Created at: {singleArticle.created_at}</p>
+      </Grid.Row>
+      <Grid.Row centered id="preview-body">
+        <p id="body" className="article-body">
+          {singleArticle.body}
+        </p>
+      </Grid.Row>
+    </>
   );
 };
 

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -8,14 +8,22 @@ import { useDispatch } from "react-redux";
 const PublishArticle = (props) => {
   const dispatch = useDispatch();
   const [message, setMessage] = useState("");
+  const location = ""
+  const international= ""
 
   useEffect(() => {
     fetchArticle(dispatch, setMessage, props.match.params.id);
   }, []);
 
   const onSubmitHandler = async (e) => {
-    //if sweden is true check if international is true or false
-  //if sweden is false then set international true
+
+    if (e.target.local.value) {
+      location = "sweden"
+        international = e.target.international.value
+    }
+    else {
+      international = true
+}
     try {
       const response = await axios.put(
         `/admin/articles/${props.match.params.id}`,
@@ -25,7 +33,8 @@ const PublishArticle = (props) => {
           category: document
             .getElementById("category")
             .firstElementChild.innerText.toLowerCase(),
-      
+          location: location,
+          international: international
         },
         {
           headers: createHeaders(),

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -14,7 +14,8 @@ const PublishArticle = (props) => {
   }, []);
 
   const onSubmitHandler = async (e) => {
-    
+    //if sweden is true check if international is true or false
+  //if sweden is false then set international true
     try {
       const response = await axios.put(
         `/admin/articles/${props.match.params.id}`,

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -41,6 +41,7 @@ const PublishArticle = (props) => {
         );
         setLoading(false);
         setMessage(response.data.message);
+        dispatch({ type: "RESET_ARTICLE_PREVIEW" })
       } catch (error) {
         setLoading(false);
         setMessage(error.response.data.message);

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -8,22 +8,12 @@ import { useDispatch } from "react-redux";
 const PublishArticle = (props) => {
   const dispatch = useDispatch();
   const [message, setMessage] = useState("");
-  const location = ""
-  const international= ""
 
   useEffect(() => {
     fetchArticle(dispatch, setMessage, props.match.params.id);
   }, []);
 
   const onSubmitHandler = async (e) => {
-
-    if (e.target.local.value) {
-      location = "sweden"
-        international = e.target.international.value
-    }
-    else {
-      international = true
-}
     try {
       const response = await axios.put(
         `/admin/articles/${props.match.params.id}`,
@@ -33,8 +23,8 @@ const PublishArticle = (props) => {
           category: document
             .getElementById("category")
             .firstElementChild.innerText.toLowerCase(),
-          location: location,
-          international: international
+          location: e.target.local.checked && "Sweden",
+          international: e.target.international.checked
         },
         {
           headers: createHeaders(),

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -14,6 +14,7 @@ const PublishArticle = (props) => {
   }, []);
 
   const onSubmitHandler = async (e) => {
+    
     try {
       const response = await axios.put(
         `/admin/articles/${props.match.params.id}`,

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -23,6 +23,7 @@ const PublishArticle = (props) => {
           category: document
             .getElementById("category")
             .firstElementChild.innerText.toLowerCase(),
+      
         },
         {
           headers: createHeaders(),

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -42,7 +42,6 @@ const PublishArticle = (props) => {
         setLoading(false);
         setMessage(response.data.message);
       } catch (error) {
-        debugger;
         setLoading(false);
         setMessage(error.response.data.message);
       }

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -43,6 +43,7 @@ const PublishArticle = (props) => {
         setMessage(response.data.message);
         dispatch({ type: "RESET_ARTICLE_PREVIEW" })
       } catch (error) {
+        debugger
         setLoading(false);
         setMessage(error.response.data.message);
       }

--- a/src/components/PublishArticle.jsx
+++ b/src/components/PublishArticle.jsx
@@ -4,44 +4,59 @@ import UpdateArticle from "./UpdateArticle";
 import createHeaders from "../modules/headers";
 import fetchArticle from "../modules/fetchArticle";
 import { useDispatch } from "react-redux";
+import { Container } from 'semantic-ui-react'
 
 const PublishArticle = (props) => {
   const dispatch = useDispatch();
   const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     fetchArticle(dispatch, setMessage, props.match.params.id);
   }, []);
 
   const onSubmitHandler = async (e) => {
-    try {
-      const response = await axios.put(
-        `/admin/articles/${props.match.params.id}`,
-        {
-          activity: "PUBLISH",
-          premium: e.target.premium.value,
-          category: document
-            .getElementById("category")
-            .firstElementChild.innerText.toLowerCase(),
-          location: e.target.local.checked && "Sweden",
-          international: e.target.international.checked
-        },
-        {
-          headers: createHeaders(),
-        }
-      );
-      setMessage(response.data.message);
-    } catch (error) {
-      setMessage(error.response.data.message);
+    const isLocal = e.target.local.checked;
+    const isInternational = e.target.international.checked;
+
+    if (isLocal === false && isInternational === false) {
+      return setMessage("Please select either local or international");
+    } else {
+      try {
+        setLoading(true);
+        const response = await axios.put(
+          `/admin/articles/${props.match.params.id}`,
+          {
+            activity: "PUBLISH",
+            premium: e.target.premium.value,
+            category: document
+              .getElementById("category")
+              .firstElementChild.innerText.toLowerCase(),
+            location: (e.target.local.checked && "Sweden") || null,
+            international: e.target.international.checked,
+          },
+          {
+            headers: createHeaders(),
+          }
+        );
+        setLoading(false);
+        setMessage(response.data.message);
+      } catch (error) {
+        debugger;
+        setLoading(false);
+        setMessage(error.response.data.message);
+      }
     }
   };
 
   return (
-    <>
-      <div id="publish-page">
-        <UpdateArticle onSubmitHandler={onSubmitHandler} message={message} />
-      </div>
-    </>
+    <Container align="center" id="publish-page">
+      <UpdateArticle
+        onSubmitHandler={onSubmitHandler}
+        message={message}
+        loading={loading}
+      />
+    </Container>
   );
 };
 

--- a/src/components/Review.jsx
+++ b/src/components/Review.jsx
@@ -36,6 +36,7 @@ const Review = () => {
     ) : (
       <List divided relaxed>
         {unpublishedArticleList.map((article) => {
+          const color = article.id === singleArticle.id? "teal" : "grey"
           return (
             <List.Item
               key={article.id}
@@ -57,7 +58,7 @@ const Review = () => {
                     to={{ pathname: `/review/${article.id}` }}
                     style={{ float: "right" }}
                   >
-                    <Button size="tiny" id={"checkout-article-" + article.id}>
+                    <Button color={color} size="tiny" id={"checkout-article-" + article.id}>
                       Checkout Article
                     </Button>
                   </Link>
@@ -71,8 +72,7 @@ const Review = () => {
         })}
       </List>
     );
-
-  const previewRender = singleArticle ? (
+  const previewRender = singleArticle.created_at ? (
     <Preview />
   ) : (
     <div id="preview-message">{previewMessage}</div>
@@ -81,10 +81,10 @@ const Review = () => {
   return (
     <div id="review-page">
       <Grid columns={2}>
-        <Grid.Column id="left">
+        <Grid.Column id="article-list">
           <Container>{unpublishedArticlesRender}</Container>
         </Grid.Column>
-        <Grid.Column>{previewRender}</Grid.Column>
+        <Grid.Column id="preview">{previewRender}</Grid.Column>
       </Grid>
     </div>
   );

--- a/src/components/Review.jsx
+++ b/src/components/Review.jsx
@@ -32,7 +32,7 @@ const Review = () => {
 
   const unpublishedArticlesRender =
     unpublishedArticleList.length === 0 ? (
-      <p id="no-articles">There isn't any unpublished articles</p>
+      <p id="no-articles">There aren't any unpublished articles</p>
     ) : (
       <List divided relaxed>
         {unpublishedArticleList.map((article) => {
@@ -72,7 +72,7 @@ const Review = () => {
         })}
       </List>
     );
-  const previewRender = singleArticle.created_at ? (
+  const previewRender = singleArticle.id && !singleArticle.published ? (
     <Preview />
   ) : (
     <div id="preview-message">{previewMessage}</div>

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import categoryList from "../modules/category";
-import { Container, Grid, Form, Dropdown, Button } from "semantic-ui-react";
+import { Container, Grid, Form, Dropdown, Button, Checkbox } from "semantic-ui-react";
 import Preview from "./Preview";
 import { useSelector } from "react-redux";
 
@@ -47,6 +47,7 @@ const UpdateArticle = (props) => {
                   type="radio"
                 />
                 <label style={{ display: "inline" }}> Premium</label>
+                <Checkbox id="checkbox-sweden" label='Local news Sweden' />
               </Form.Field>
               <Button id="publish-btn" type="submit">
                 Publish Article

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import categoryList from "../modules/category";
-import { Container, Grid, Form, Dropdown, Button } from "semantic-ui-react";
+import {
+  Container,
+  Grid,
+  Form,
+  Dropdown,
+  Button,
+  Checkbox,
+} from "semantic-ui-react";
 import Preview from "./Preview";
 import { useSelector } from "react-redux";
 
@@ -12,84 +19,80 @@ const UpdateArticle = (props) => {
   return (
     <>
       {selectedArticle && (
-        <Grid >
+        <Grid>
+          <Grid.Column width={1} />
           <Grid.Column id="preview" width={8}>
             <Preview selectedArticle={selectedArticle} />
           </Grid.Column>
           <Grid.Column width={4}>
             <Container id="form-container">
-            <Link to="/review" id="back-btn">
-              <Button>Back to list</Button>
-            </Link>
-            {props.message === "Article successfully published!" ? (
-              <p id="success-message">{props.message}</p>
-            ) : (
-              <Form
-                className="publishing-form"
-                onSubmit={(e) => props.onSubmitHandler(e)}
-              >
-                <Form.Field>
-                  <label>Category</label>
-                  <Dropdown
-                    selection
-                    id="category"
-                    name="category"
-                    placeholder={selectedArticle.category}
-                    options={categories}
-                  ></Dropdown>
-                </Form.Field>
-                <Form.Field>
-                  <input
-                    id="radio-free"
-                    label="Free"
-                    name="premium"
-                    value={true}
-                    type="radio"
-                    defaultChecked
-                  />
-                  <label style={{ display: "inline" }}> Free </label>
-                  <input
-                    id="radio-premium"
-                    label="Premium"
-                    name="premium"
-                    value={false}
-                    type="radio"
-                  />
-                  <label style={{ display: "inline" }}> Premium</label>
-                </Form.Field>
-                <Form.Field>
-                  <input
-                    id="checkbox-sweden"
-                    name="local"
-                    value={false}
-                    type="checkbox"
-                  />
-                  <label style={{ display: "inline" }}>
-                    {" "}
-                    Local News Sweden{" "}
-                  </label>
-                  <input
-                    id="checkbox-International"
-                    name="international"
-                    value={false}
-                    type="checkbox"
-                  />
-                  <label style={{ display: "inline" }}>
-                    {" "}
-                    International News{" "}
-                  </label>
-                </Form.Field>
-                <Button
-                  loading={props.loading}
-                  color="teal"
-                  id="publish-btn"
-                  type="submit"
+              <Link to="/review" id="back-btn">
+                <Button>Back to list</Button>
+              </Link>
+              {props.message === "Article successfully published!" ? (
+                <p id="success-message">{props.message}</p>
+              ) : (
+                <Form
+                  className="publishing-form"
+                  onSubmit={(e) => props.onSubmitHandler(e)}
                 >
-                  Publish Article
-                </Button>
-                <p id="error-message">{props.message}</p>
-              </Form>
-            )}
+                  <Form.Field>
+                    <label>Category</label>
+                    <Dropdown
+                      selection
+                      id="category"
+                      name="category"
+                      placeholder={selectedArticle.category}
+                      options={categories}
+                    ></Dropdown>
+                  </Form.Field>
+                  <Form.Field>
+                    <Checkbox
+                      toggle
+                      id="radio-free"
+                      label="Free"
+                      name="premium"
+                      value={false}
+                      type="radio"
+                      defaultChecked
+                    />
+                    <Checkbox
+                      toggle
+                      id="radio-premium"
+                      label="Premium"
+                      name="premium"
+                      value={true}
+                      type="radio"
+                    />
+                  </Form.Field>
+                  <Form.Field>
+                    <Checkbox
+                      id="checkbox-sweden"
+                      name="local"
+                      value={false}
+                      type="checkbox"
+                      label="Local News Sweden"
+                    />
+                    <Checkbox
+                      id="checkbox-International"
+                      name="international"
+                      value={false}
+                      type="checkbox"
+                      label="International News"
+                      style={{paddingRight: "2px"}}
+                    />
+                  </Form.Field>
+                  <Button
+                    loading={props.loading}
+                    color="teal"
+                    id="publish-btn"
+                    type="submit"
+                  >
+                    Publish Article
+                  </Button>
+                  <p id="error-message">{props.message}</p>
+                </Form>
+              )}
             </Container>
           </Grid.Column>
         </Grid>

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -58,14 +58,14 @@ const UpdateArticle = (props) => {
               <Form.Field>
                   <input 
                   id="checkbox-sweden" 
-                  label="Local News Sweden" 
-                  name="Local News Sweden"
+                  name="local"
+                  value={false}
                   type="checkbox" />
                 <label style={{ display: "inline" }}> Local News Sweden </label>
                 <input
                   id="checkbox-International"
-                  label="International News"
-                  name="International News"
+                  name="international"
+                  value={false}
                   type="checkbox" />
                 <label style={{ display: "inline" }}> International News </label>
                 

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -1,6 +1,13 @@
 import React from "react";
 import categoryList from "../modules/category";
-import { Container, Grid, Form, Dropdown, Button, Checkbox } from "semantic-ui-react";
+import {
+  Container,
+  Grid,
+  Form,
+  Dropdown,
+  Button,
+  Checkbox,
+} from "semantic-ui-react";
 import Preview from "./Preview";
 import { useSelector } from "react-redux";
 
@@ -47,7 +54,21 @@ const UpdateArticle = (props) => {
                   type="radio"
                 />
                 <label style={{ display: "inline" }}> Premium</label>
-                <Checkbox id="checkbox-sweden" label='Local news Sweden' />
+                </Form.Field>
+              <Form.Field>
+                  <input 
+                  id="checkbox-sweden" 
+                  label="Local News Sweden" 
+                  name="Local News Sweden"
+                  type="checkbox" />
+                <label style={{ display: "inline" }}> Local News Sweden </label>
+                <input
+                  id="checkbox-International"
+                  label="International News"
+                  name="International News"
+                  type="checkbox" />
+                <label style={{ display: "inline" }}> International News </label>
+                
               </Form.Field>
               <Button id="publish-btn" type="submit">
                 Publish Article

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -3,18 +3,11 @@ import { Link } from "react-router-dom";
 import categoryList from "../modules/category";
 import { Container, Grid, Form, Dropdown, Button } from "semantic-ui-react";
 import Preview from "./Preview";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 
 const UpdateArticle = (props) => {
   const selectedArticle = useSelector((state) => state.article);
   const categories = categoryList();
-  const dispatch = useDispatch()
-
-  const resetSingleArticle = () => {
-    dispatch({
-      type: "RESET_ARTICLE_PREVIEW"
-    })
-  }
 
   return (
     <>
@@ -25,7 +18,7 @@ const UpdateArticle = (props) => {
           </Grid.Column>
           <Grid.Column width={4}>
             <Container id="form-container">
-            <Link to="/review" id="back-btn" onClick={resetSingleArticle}>
+            <Link to="/review" id="back-btn">
               <Button>Back to list</Button>
             </Link>
             {props.message === "Article successfully published!" ? (

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -1,12 +1,7 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import categoryList from "../modules/category";
-import {
-  Container,
-  Grid,
-  Form,
-  Dropdown,
-  Button,
-} from "semantic-ui-react";
+import { Container, Grid, Form, Dropdown, Button } from "semantic-ui-react";
 import Preview from "./Preview";
 import { useSelector } from "react-redux";
 
@@ -17,62 +12,85 @@ const UpdateArticle = (props) => {
   return (
     <>
       {selectedArticle && (
-        <Grid columns={2}>
-          <Grid.Column id="left">
-            <Container>
-              <Preview selectedArticle={selectedArticle} />
-            </Container>
+        <Grid >
+          <Grid.Column id="preview" width={8}>
+            <Preview selectedArticle={selectedArticle} />
           </Grid.Column>
-          <Grid.Column>
-            <Form onSubmit={(e) => props.onSubmitHandler(e)}>
-              <Form.Field>
-                <label>Category</label>
-                <Dropdown
-                  selection
-                  id="category"
-                  name="category"
-                  placeholder={selectedArticle.category}
-                  options={categories}
-                ></Dropdown>
-              </Form.Field>
-              <Form.Field>
-                <input
-                  id="radio-free"
-                  label="Free"
-                  name="premium"
-                  value={true}
-                  type="radio"
-                  defaultChecked
-                />
-                <label style={{ display: "inline" }}> Free </label>
-                <input
-                  id="radio-premium"
-                  label="Premium"
-                  name="premium"
-                  value={false}
-                  type="radio"
-                />
-                <label style={{ display: "inline" }}> Premium</label>
-              </Form.Field>
-              <Form.Field>
-                <input 
-                  id="checkbox-sweden" 
-                  name="local"
-                  value={false}
-                  type="checkbox" />
-                <label style={{ display: "inline" }}> Local News Sweden </label>
-                <input
-                  id="checkbox-International"
-                  name="international"
-                  value={false}
-                  type="checkbox" />
-                <label style={{ display: "inline" }}> International News </label>
-              </Form.Field>
-              <Button id="publish-btn" type="submit">
-                Publish Article
-              </Button>
-              <p id="message">{props.message}</p>
-            </Form>
+          <Grid.Column width={4}>
+            <Container id="form-container">
+            <Link to="/review" id="back-btn">
+              <Button>Back to list</Button>
+            </Link>
+            {props.message === "Article successfully published!" ? (
+              <p id="success-message">{props.message}</p>
+            ) : (
+              <Form
+                className="publishing-form"
+                onSubmit={(e) => props.onSubmitHandler(e)}
+              >
+                <Form.Field>
+                  <label>Category</label>
+                  <Dropdown
+                    selection
+                    id="category"
+                    name="category"
+                    placeholder={selectedArticle.category}
+                    options={categories}
+                  ></Dropdown>
+                </Form.Field>
+                <Form.Field>
+                  <input
+                    id="radio-free"
+                    label="Free"
+                    name="premium"
+                    value={true}
+                    type="radio"
+                    defaultChecked
+                  />
+                  <label style={{ display: "inline" }}> Free </label>
+                  <input
+                    id="radio-premium"
+                    label="Premium"
+                    name="premium"
+                    value={false}
+                    type="radio"
+                  />
+                  <label style={{ display: "inline" }}> Premium</label>
+                </Form.Field>
+                <Form.Field>
+                  <input
+                    id="checkbox-sweden"
+                    name="local"
+                    value={false}
+                    type="checkbox"
+                  />
+                  <label style={{ display: "inline" }}>
+                    {" "}
+                    Local News Sweden{" "}
+                  </label>
+                  <input
+                    id="checkbox-International"
+                    name="international"
+                    value={false}
+                    type="checkbox"
+                  />
+                  <label style={{ display: "inline" }}>
+                    {" "}
+                    International News{" "}
+                  </label>
+                </Form.Field>
+                <Button
+                  loading={props.loading}
+                  color="teal"
+                  id="publish-btn"
+                  type="submit"
+                >
+                  Publish Article
+                </Button>
+                <p id="error-message">{props.message}</p>
+              </Form>
+            )}
+            </Container>
           </Grid.Column>
         </Grid>
       )}

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -6,7 +6,6 @@ import {
   Form,
   Dropdown,
   Button,
-  Checkbox,
 } from "semantic-ui-react";
 import Preview from "./Preview";
 import { useSelector } from "react-redux";
@@ -54,9 +53,9 @@ const UpdateArticle = (props) => {
                   type="radio"
                 />
                 <label style={{ display: "inline" }}> Premium</label>
-                </Form.Field>
+              </Form.Field>
               <Form.Field>
-                  <input 
+                <input 
                   id="checkbox-sweden" 
                   name="local"
                   value={false}
@@ -68,7 +67,6 @@ const UpdateArticle = (props) => {
                   value={false}
                   type="checkbox" />
                 <label style={{ display: "inline" }}> International News </label>
-                
               </Form.Field>
               <Button id="publish-btn" type="submit">
                 Publish Article

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -24,7 +24,6 @@ const UpdateArticle = (props) => {
           <Grid.Column id="preview" width={8}>
             <Preview selectedArticle={selectedArticle} />
           </Grid.Column>
-          <Grid.Column width={4}>
             <Container id="form-container">
               <Link to="/review" id="back-btn">
                 <Button>Back to list</Button>
@@ -33,7 +32,7 @@ const UpdateArticle = (props) => {
                 <p id="success-message">{props.message}</p>
               ) : (
                 <Form
-                  className="publishing-form"
+                  id="publishing-form"
                   onSubmit={(e) => props.onSubmitHandler(e)}
                 >
                   <Form.Field>
@@ -79,22 +78,23 @@ const UpdateArticle = (props) => {
                       value={false}
                       type="checkbox"
                       label="International News"
-                      style={{paddingRight: "2px"}}
+                      style={{ paddingRight: "2px" }}
                     />
                   </Form.Field>
-                  <Button
-                    loading={props.loading}
-                    color="teal"
-                    id="publish-btn"
-                    type="submit"
-                  >
-                    Publish Article
-                  </Button>
+                  <Form.Field>
+                    <Button
+                      loading={props.loading}
+                      color="teal"
+                      id="publish-btn"
+                      type="submit"
+                    >
+                      Publish Article
+                    </Button>
+                  </Form.Field>
                   <p id="error-message">{props.message}</p>
                 </Form>
               )}
             </Container>
-          </Grid.Column>
         </Grid>
       )}
     </>

--- a/src/components/UpdateArticle.jsx
+++ b/src/components/UpdateArticle.jsx
@@ -3,11 +3,18 @@ import { Link } from "react-router-dom";
 import categoryList from "../modules/category";
 import { Container, Grid, Form, Dropdown, Button } from "semantic-ui-react";
 import Preview from "./Preview";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 
 const UpdateArticle = (props) => {
   const selectedArticle = useSelector((state) => state.article);
   const categories = categoryList();
+  const dispatch = useDispatch()
+
+  const resetSingleArticle = () => {
+    dispatch({
+      type: "RESET_ARTICLE_PREVIEW"
+    })
+  }
 
   return (
     <>
@@ -18,7 +25,7 @@ const UpdateArticle = (props) => {
           </Grid.Column>
           <Grid.Column width={4}>
             <Container id="form-container">
-            <Link to="/review" id="back-btn">
+            <Link to="/review" id="back-btn" onClick={resetSingleArticle}>
               <Button>Back to list</Button>
             </Link>
             {props.message === "Article successfully published!" ? (

--- a/src/components/WritingForm.jsx
+++ b/src/components/WritingForm.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Form, Button, Input, Dropdown, Image } from "semantic-ui-react";
+import { Form, Button, Input, Dropdown } from "semantic-ui-react";
 import categoryList from "../modules/category";
 
 const WritingForm = (props) => {

--- a/src/components/WritingForm.jsx
+++ b/src/components/WritingForm.jsx
@@ -39,8 +39,8 @@ const WritingForm = (props) => {
             placeholder="Write your article here"
           />
         </Form.Field>
-        <Button id="post" type="submit">
-          Post Article
+        <Button color="teal" loading={props.loading} id="post" type="submit">
+          Submit Article
         </Button>
         <p id="message">{props.message}</p>
       </Form>

--- a/src/css/Preview.css
+++ b/src/css/Preview.css
@@ -1,7 +1,9 @@
-#preview, #preview-message {
+#preview {
   height: calc(100vh - 180px);
   overflow-x: hidden;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 #preview-message {
@@ -11,36 +13,37 @@
   text-align: center;
 }
 
-#image {
-  margin: 0;
-  padding: 0;
-  max-width: unset;
-  max-height: unset;
-  height: 250px;
-  width: 80%;
+#image-container {
+  width: 800px;
+  height: 400px;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.image {
+  width: 800px;
+  height: 400px;
 }
 
 #preview-title {
-  left: 14%;
-  width: 70%;
-  text-align: left;
-  position: absolute;
-  bottom: 21px;
-  text-shadow: 2px 2px 3px black;
+  position: relative;
+  bottom: 100px;
+  background-color: rgba(0,0,0,0.44);
+  padding: 7px;
+  padding-left: 40px;
+  width: fit-content;
+  word-wrap: break-word;
 }
 
 #created-text {
-  max-width: unset;
-  width: 80%;
-  max-height: 2rem;
-}
-
-#preview-body {
-  max-width: unset;
-  max-height: unset;
+  text-align: center;
+  margin-top: 25px;
+  font-size: 20px;
+  color: darkgray
 }
 
 #body {
+  margin-top: 25px;
   text-align: justify !important;
   word-wrap: normal;
   font-size: 18px;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -17,6 +17,12 @@ p {
 .header.menu {
   background-color: #409d9b !important;
   width: 100% !important;
+  margin-bottom: 60px !important;
+}
+
+.header-container {
+  background-color: #409d9b !important;
+  width: 100% !important;
 }
 
 .header > * {
@@ -30,8 +36,7 @@ p {
 
 .writing-container {
   float: left; 
-  padding-left: 40px; 
-  padding-top: 40px;
+  padding-left: 80px;
   width: 40% !important;
 }
 
@@ -52,4 +57,30 @@ p {
 
 #login-form > * {
   margin: 1px
+}
+
+#publish-page {
+  width: 100%;
+}
+
+#form-container {
+  height: 428px !important; 
+  width: 428px; 
+  display: flex !important; 
+  flex-direction: column !important; 
+  justify-content: space-between !important;
+  align-items: flex-start;
+}
+
+.publishing-form {
+  width: 300px;
+  height: 300px;
+  display: flex; 
+  flex-direction: column; 
+  justify-content: space-evenly;
+  align-items: stretch
+}
+
+label {
+  margin: 10px !important;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -69,7 +69,7 @@ p {
   display: flex !important; 
   flex-direction: column !important; 
   justify-content: space-between !important;
-  align-items: flex-start;
+  align-items: flex-start !important;
 }
 
 .publishing-form {
@@ -83,4 +83,9 @@ p {
 
 label {
   margin: 10px !important;
+}
+
+#error-message {
+  position: absolute;
+  top: 300px;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -64,15 +64,16 @@ p {
 }
 
 #form-container {
+  margin-left: -100px;
   height: 428px !important; 
-  width: 428px; 
+  width: 428px;
   display: flex !important; 
   flex-direction: column !important; 
   justify-content: space-between !important;
   align-items: flex-start !important;
 }
 
-.publishing-form {
+#publishing-form {
   width: 300px;
   height: 300px;
   display: flex; 
@@ -82,7 +83,7 @@ p {
 }
 
 label {
-  margin: 10px !important;
+  margin: 10px;
 }
 
 #error-message {

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -19,6 +19,12 @@ const rootReducer = (state = initialState, action) => {
         ...state,
         article: action.payload.article,
       };
+    case "RESET_ARTICLE_PREVIEW":
+      const article = state.article
+      return {
+        ...state,
+        article: { ...article, published: true}
+      }
     default:
       return state;
   }

--- a/src/state/store/initialState.js
+++ b/src/state/store/initialState.js
@@ -1,6 +1,6 @@
 const initialState = {
   authenticatedAs: "",
   uid: "",
-  article: null,
+  article: {},
 };
 export default initialState;


### PR DESCRIPTION
## [PT LINK]( https://www.pivotaltracker.com/story/show/172888054 )
### User Story
```
As an editor
In order to give local news to the client
I would like to be able to associate the article with the location
```

# Feature
* Editor can select whether the article should have attribute `local: "Sweden"`, and/or `international: true`


- Editor cannot publish an article without selecting one of them
- Editor can navigate from the publishing page to the review page
- When the article is published the form disappears and a success message is shown
- When the article is published it is no longer shown in the article preview on the previous page

## Screenshots 
![gif](https://user-images.githubusercontent.com/61984272/83947144-8a856900-a815-11ea-9cc9-b09f25ce99ab.gif)